### PR TITLE
Use a default (recommended) upload speed

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,6 @@ platform = espressif32 @ ^6
 board = esp-wrover-kit
 framework = arduino
 monitor_speed = 115200
-upload_speed = 921600
 monitor_filters =
     esp32_exception_decoder
     time


### PR DESCRIPTION
The high upload speed can lead to uploading issues.